### PR TITLE
scope global style to component

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Minimalist Svelte action to simply inject an `active` class into route-matched l
 
 <!-- alternatively just add the appropriate .active class styles to an imported stylesheet -->
 <style>
-  :global(a.active) {
+  a:global(.active) {
     color: red;
   }
 </style>


### PR DESCRIPTION
Your current example creates a global style that will be vailable to the full application.
You should instead create a scoped global style. The `a` is scoped to the component and you just tell the Svelte compiler to not throw away the styles for the `.active` class.